### PR TITLE
Turn Skill Rust off by default

### DIFF
--- a/src/options.cpp
+++ b/src/options.cpp
@@ -2606,13 +2606,14 @@ void options_manager::add_options_debug()
 
     add( "SKILL_RUST", "debug", to_translation( "Skill rust" ),
          to_translation( "Set the type of skill rust.  Vanilla: Skill rust can decrease levels.  - Capped: Skill rust cannot decrease levels.  - Off: None at all." ),
-         //~ plain, default, normal
+        //~ vanilla DDA; can decrease levels
     {   { "vanilla", to_translation( "Vanilla" ) },
         //~ capped at a value
         { "capped", to_translation( "Capped" ) },
+        //~ default
         { "off", to_translation( "Off" ) }
     },
-    "vanilla" );
+    "off" );
 
     add_empty_line();
 


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
Leave the headings unless they don't apply to your PR.

Please read carefully and don't delete the comments delimited by "< !--" and "-- >"
Once a pull request is submitted, automatic stylistic and consistency checks will be performed on the PR's changes.
The results of these can be either seen under the "Files changed" section of a PR or in the check's details.

NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them. -->

#### Summary
Balance "Turn Skill Rust off by default"
<!-- This section should consist of exactly one line, edit the one above.
1. Replace the word "Category" with one of these words: Features, Content, Interface, Mods, Balance, Bugfixes, Performance, Infrastructure, Build, I18N.
2. Replace the text inside the quotes with a brief description of your changes.
Or if you don't want a changelog entry, replace the whole line with just the word "None" (with no quotes).
For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md
If approved and merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt -->

#### Purpose of change

By default, skill rust is turned on. Many players with more limited playtime (myself) do not want to spend our precious gaming time retraining skills we've already learned, regardless of how realistic it is. It's also yet another system for new players to learn in an already frustratingly complicated game. Enabling skill rust by default is not welcoming and accommodating for anyone but the most hardcore of players. 

As such, skill rust should be disabled by default and players who want it (and are probably already familiar enough with the game options to voluntarily enable it) can be free to turn it back on as they desire. 
<!-- With a few sentences, describe your reasons for making this change.  If it relates to an existing issue, you can link it with a # followed by the GitHub issue number, like #1234.  If your pull request *fully* resolves an issue, include the word "Fix" or "Fixes" before the issue number, like: Fixes #xxxx
If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified. -->

#### Describe the solution

_Warning: incoherent & melodramatic rambling incoming. Proceed at your own risk._

tbqh, if I had to name a single thing that sent me over the edge to stop playing DDA experimentals, it would be this one. 

sometimes the little things just really add up. Lots of people hated forced-enabled Skill Rust in DDA, and I tried my hand at trying to [bring](https://www.reddit.com/r/cataclysmdda/comments/12qxko5/no_skill_rust_mod_v10/) [the](https://www.reddit.com/r/cataclysmdda/comments/acye27/is_there_a_way_to_turn_off_skill_rust_i_hate_it/) [concerns](https://www.reddit.com/r/cataclysmdda/comments/143n9h8/skill_rust_disable/) people had [to the table](https://github.com/CleverRaven/Cataclysm-DDA/pull/65141), but the dismissive interaction from the maintainers just didn't sit right with me. 

Thankfully, this version still has the code for the in-game option, and it took just a single line to disable it by default. **And the option is still there for those who enjoy playing the game in a different way than I do! Crazy how that works, right?** am I being petty? sure. but, you know what? it hurt my feelings to feel unheard and it's okay to admit that.

The DDA devs have a right to make their own game be whatever they want it to be, and I really respect their technical prowess and organisational capacity to keep the project moving forward in a way no fork will probably ever be able to meet, but it really feels like they're just so dead-set on catering to the hardcore players that it feels exclusive to everyone else.

Another user on reddit made a really eloquent post about the self-perpetuating cycle of increased difficulty that continues to cyclically alienate more casual players.
> *[It's such a huge struggle to get the "you died" crack to the hardened, seasoned, battered, scarred veterans that crave it that [the C:DDA developers] end up making the game utterly hostile towards everyone else](https://www.reddit.com/r/cataclysmdda/comments/12e2748/development_strategy/jf9vb5x/)* --  /u/fallen_one_fs

I couldn't have stated it better myself. The phrase 'you died crack' is going to live in my head rent free forever now; it's so perfectly descriptive of the cycle at play.

Anyway, I probably sound like a raving lunatic at this point. My point is just that despite how simple it is, this PR is incredibly cathartic for me.

Wishing the best for any DDA developer who reads this. You guys are generally awesome, and the reason I get so upset about this kind of thing is because I really love your game. It feels bad to leave, and I know for a fact that I'm going to be missing a whole lot of awesome stuff with this fork. But, totally unrelated to skill rust, I really think that it's ultimately for the best to create this fork with how attached I am to the 2040s lore. It's clear to me that unless I take action to preserve that history, no one else will.

So, in a roundabout way, I suppose this is a thank you for inspiring me to take the leap and learn more about how this game works to be able to build and share the version of it that I like to play. That's the magic of copyleft, and even if I may have my development disagreements with the C:DDA team, I still love and respect you guys as awesome, kind, human beings who are trying to make the world a more joyful place and for the countless unpaid hours you put in to showing the world what's possible in the world of open source ❤️ 

For any random people reading this, please do NOT take this post as justification or approval to harass or gang up on the DDA devs. It's possible to disagree with the DDA development vision but still respect that community's right to choose to build/play their game however they want and value their contributions. Treat others the way you would like to be treated and make sure that anyone from that side of the fence feels welcome, heard, and respected here.
<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged. -->